### PR TITLE
Split up the document-ready into three prefixes.

### DIFF
--- a/snippets/document-ready-1.cson
+++ b/snippets/document-ready-1.cson
@@ -1,4 +1,4 @@
 '.source.js':
   'jQuery(document).ready':
-    'prefix': 'ready-1'
+    'prefix': 'jquery.ready'
     'body': 'jQuery(document).ready(function(\$) {\n\t$1\n});$0'

--- a/snippets/document-ready-1.cson
+++ b/snippets/document-ready-1.cson
@@ -1,4 +1,4 @@
 '.source.js':
   'jQuery(document).ready':
-    'prefix': 'ready'
+    'prefix': 'ready-1'
     'body': 'jQuery(document).ready(function(\$) {\n\t$1\n});$0'

--- a/snippets/document-ready-2.cson
+++ b/snippets/document-ready-2.cson
@@ -1,4 +1,4 @@
 '.source.js':
   '$(document).ready':
-    'prefix': 'ready-2'
+    'prefix': 'document.ready'
     'body': '\$(document).ready(function() {\n\t$1\n});$0'

--- a/snippets/document-ready-2.cson
+++ b/snippets/document-ready-2.cson
@@ -1,4 +1,4 @@
 '.source.js':
   '$(document).ready':
-    'prefix': 'ready'
+    'prefix': 'ready-2'
     'body': '\$(document).ready(function() {\n\t$1\n});$0'

--- a/snippets/document-ready.cson
+++ b/snippets/document-ready.cson
@@ -1,4 +1,4 @@
 '.source.js':
   'document.ready - $(function()':
-    'prefix': 'ready'
+    'prefix': 'ready-3'
     'body': '\$(function() {\n\t$1\n});$0'

--- a/snippets/document-ready.cson
+++ b/snippets/document-ready.cson
@@ -1,4 +1,4 @@
 '.source.js':
   'document.ready - $(function()':
-    'prefix': 'ready-3'
+    'prefix': 'ready'
     'body': '\$(function() {\n\t$1\n});$0'


### PR DESCRIPTION
If all are set to "ready" then only the last file will be used, which is document-ready.cson

All returns the same as before, just the prefixes are changed.
