### PR TITLE
Fix Deprecated selector.

### DIFF
--- a/keymaps/jquery-snippets.cson
+++ b/keymaps/jquery-snippets.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'.atom-workspace':
   'ctrl-alt-o': 'jquery-snippets:toggle'


### PR DESCRIPTION
Atom 0.186 is complaining about the deprecated selector.
